### PR TITLE
Refactor (4) - 1 : 기능 수정 (낚시터 물때 위젯)

### DIFF
--- a/backend/routes/route.py
+++ b/backend/routes/route.py
@@ -32,9 +32,9 @@ def set_route(app: Flask, model, device):
         return 'Welcome to SNAPISH'
 
     # 물떼 정보 받아오기
-    @app.route('/backend/mulddae', methods=['POST', 'GET'])
+    @app.route('/api/tidecycle', methods=['GET'])
     def get_mulddae():
-        now_date = request.form.get('nowdate')
+        now_date = request.args.get('nowdate')
         if not now_date:
             return error_response("'nowdate' 파라미터가 필요합니다.",
                                 "Bad Request",

--- a/backend/routes/route.py
+++ b/backend/routes/route.py
@@ -17,7 +17,7 @@ from decorator import token_required
 from services.weather_service import get_sea_weather_by_seapostid, get_weather_by_coordinates
 from services.lunar_mulddae import get_mulddae_cycle, calculate_moon_phase
 from services.openai_assistant import assistant_talk_request, assistant_talk_get
-from utils import allowed_file, optimize_image, get_full_url
+from utils import allowed_file, optimize_image, get_full_url, success_response, error_response
 
 from models.model import (
     Session,
@@ -36,26 +36,33 @@ def set_route(app: Flask, model, device):
     def get_mulddae():
         now_date = request.form.get('nowdate')
         if not now_date:
-            return jsonify({"error": "The 'nowdate' parameter is required"}), 400
-
+            return error_response("'nowdate' 파라미터가 필요합니다.",
+                                "Bad Request",
+                                400)
         try:
             parsed_date = datetime.strptime(now_date, "%Y-%m-%d")
         except ValueError:
-            return jsonify({"error": "Invalid date format. Use YYYY-MM-DD"}), 400
+            return error_response("Invalid date format. Use YYYY-MM-DD",
+                                "Bad Request",
+                                400)
 
         try:
             lunar_date, seohae, other = get_mulddae_cycle(parsed_date)
             moon_phase = calculate_moon_phase(parsed_date)
+            
             json_result = {
                 "lunar_date": lunar_date,
                 "seohae": seohae,
                 "other": other,
                 "moon_phase": moon_phase,
             }
-            return jsonify(json_result)
+            return success_response("요청이 성공적으로 처리되었습니다.",
+                                    json_result)
+
         except Exception as e:
-            logging.error(f"Unexpected error: {e}")
-            return jsonify({"error": "Internal server error"}), 500
+            return error_response("서버 오류 발생",
+                                  "Internal server error",
+                                  500)
         
 
     @app.route('/signup', methods=['POST', 'GET'])

--- a/backend/routes/route.py
+++ b/backend/routes/route.py
@@ -32,7 +32,7 @@ def set_route(app: Flask, model, device):
         return 'Welcome to SNAPISH'
 
     # 물떼 정보 받아오기
-    @app.route('/api/tidecycle', methods=['GET'])
+    @app.route('/api/tide-cycles', methods=['GET'])
     def get_mulddae():
         now_date = request.args.get('nowdate')
         if not now_date:

--- a/frontend/src/components/MulddaeWidget.vue
+++ b/frontend/src/components/MulddaeWidget.vue
@@ -74,19 +74,6 @@ const currentDate = computed(() => {
   return new Date().toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\. /g, '-').replace('.', '')
 })
 
-const fetchTodayMulddae = () => {
-  const today = new Date().toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\. /g, '-').replace('.', '')
-  const cachedDate = localStorage.getItem("mulddaeDate")
-  
-  // 캐시된 데이터가 없거나 날짜가 다른 경우에만 fetch 실행
-  if (!cachedDate || cachedDate !== today) {
-    console.log("info: No cached data found or date mismatch, fetching new data")
-    store.dispatch('fetchMulddae', today)
-  } else {
-    console.log("info: Using cached mulddae data")
-  }
-}
-
 const getMoonIcon = (phase) => {
   if (phase === 0) return moonPhaseIcons["new"]
   if (phase > 0 && phase < 0.25) return moonPhaseIcons["waxing_crescent"]
@@ -116,8 +103,7 @@ const refreshCard = async () => {
     console.log("Refresh Mulddae Widget: Cached mulddae data cleared.")
     localStorage.removeItem("mulddae")
     localStorage.removeItem("mulddaeDate")
-    await store.dispatch("fetchMulddae")
-    console.log("success: Mulddae data refreshed.")
+    await store.dispatch("fetchMulddaeInfo")
   } catch (error) {
     console.error("Error refreshing mulddae data:", error)
   }
@@ -129,7 +115,6 @@ function updateLocation() {
 }
 
 onMounted(() => {
-  fetchTodayMulddae()
   updateLocation()
 })
 </script>

--- a/frontend/src/services/mulddaeService.js
+++ b/frontend/src/services/mulddaeService.js
@@ -15,14 +15,6 @@ export async function fetchMulddae(date) {
     return response.data.data;
   } catch (error) {
     console.error("Error fetching mulddae data:", error);
-    return { error: error.message };
+    return null;
   }
 }
-
-// Example: If making API calls that include identifiers, ensure 'id' is used
-
-// export async function getMulddaeData() {
-//     const response = await axios.get('/backend/mulddae');
-//     // Ensure response data uses 'id' if applicable
-//     return response.data;
-// }

--- a/frontend/src/services/mulddaeService.js
+++ b/frontend/src/services/mulddaeService.js
@@ -1,17 +1,14 @@
 import axios from "@/axios"; // Axios 인스턴스 임포트
 
 const baseUrl = process.env.VUE_APP_BASE_URL;
-const apimulddaeBaseUrl = `${baseUrl}/backend/mulddae`;
+const apimulddaeBaseUrl = `${baseUrl}/api/tidecycle`;
 
 export async function fetchMulddae(date) {
   console.log(`Call_fetchMulddae : ${date}`);
   try {
-    const response = await axios.post(
-      apimulddaeBaseUrl,
-      new URLSearchParams({ nowdate: date }).toString(),
-      {
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
+    const response = await axios.get(apimulddaeBaseUrl,{
+        params: {
+          nowdate: date,
         },
       }
     );

--- a/frontend/src/services/mulddaeService.js
+++ b/frontend/src/services/mulddaeService.js
@@ -15,7 +15,7 @@ export async function fetchMulddae(date) {
         },
       }
     );
-    return response.data;
+    return response.data.data;
   } catch (error) {
     console.error("Error fetching mulddae data:", error);
     return { error: error.message };

--- a/frontend/src/services/mulddaeService.js
+++ b/frontend/src/services/mulddaeService.js
@@ -1,7 +1,7 @@
 import axios from "@/axios"; // Axios 인스턴스 임포트
 
 const baseUrl = process.env.VUE_APP_BASE_URL;
-const apimulddaeBaseUrl = `${baseUrl}/api/tidecycle`;
+const apimulddaeBaseUrl = `${baseUrl}/api/tide-cycles`;
 
 export async function fetchMulddae(date) {
   console.log(`Call_fetchMulddae : ${date}`);

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -5,9 +5,6 @@ import { fetchMulddae } from "../services/mulddaeService";
 
 const baseUrl = process.env.VUE_APP_BASE_URL;
 
-// Existing actions
-let isFetching = false;
-
 export default createStore({
   state: {
     // Existing state
@@ -16,6 +13,7 @@ export default createStore({
     error: null,
     mulddae: JSON.parse(localStorage.getItem('mulddae')) || null, // 물때 정보 추가
     mulddaeDate: null,
+    isFetching: false,
 
     // Authentication state
     isAuthenticated: !!localStorage.getItem("token"),
@@ -40,6 +38,9 @@ export default createStore({
     },
     setError(state, error) {
       state.error = error;
+    },  
+    setFetching(state, status) {
+      state.isFetching = status;
     },
     setMulddae(state, mulddae) {
       state.mulddae = mulddae; // 물때 정보 업데이트
@@ -118,14 +119,10 @@ export default createStore({
     }
   },
   actions: {
-    async fetchMulddae({ commit }) {
-      if (isFetching) {
-        console.log("info: Already fetching mulddae data, request ignored.");
-        return;
-      }
+    async fetchMulddaeInfo({ commit, state }) {
 
       console.log("vuex : fetchMulddae action triggered.");
-      isFetching = true;
+      state.isFetching = true;
       commit("setLoading", true);
 
       try {
@@ -153,6 +150,7 @@ export default createStore({
             );
           }
 
+          // Call API Endpoint
           const mulddaeData = await fetchMulddae(today);
           commit("setMulddae", mulddaeData);
 
@@ -171,7 +169,7 @@ export default createStore({
         console.error("Error fetching mulddae:", error);
         commit("setError", error);
       } finally {
-        isFetching = false;
+        commit("setFetching", false); 
         commit("setLoading", false);
       }
     },
@@ -385,7 +383,7 @@ export default createStore({
     async fetchInitialData({ dispatch }) {
       try {
         await Promise.all([
-          dispatch('fetchMulddae'),
+          dispatch('fetchMulddaeInfo'),
           dispatch('fetchCatches'),
           dispatch('fetchHotIssues')
         ]);

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -136,7 +136,7 @@ export default createStore({
         const MAX_AGE = 3600000;
         const isExpired = cachedTimestamp && (now.getTime() - parseInt(cachedTimestamp) > MAX_AGE);
 
-        if (cachedMulddae && cachedDate === today && !isExpired) {
+        if (cachedMulddae !== "null" && cachedDate === today && !isExpired) {
           console.log("success : Loaded mulddae from localStorage.");
           commit("setMulddae", JSON.parse(cachedMulddae));
         } else {
@@ -144,10 +144,14 @@ export default createStore({
             console.log(
               "info : mulddaeDate is not found in localStorage, fetching new data."
             );
-          } else if (cachedDate !== today) {
+          }
+          if (cachedDate !== today) {
             console.log(
               "info : Cached date is different from today, fetching new data."
             );
+          }
+          if (!cachedMulddae == "null") {
+            console.log("info : CachedMulddae is corrupted, fetching new data.");
           }
 
           // Call API Endpoint


### PR DESCRIPTION
기존
- 웹페이지 접속 시, API (/backend/mulddae) 에 POST method로 오늘 날짜 Request
- API에서 오늘 날짜 기준 달모앙, 서해&그외지역 물때, 음력 날짜 JSON 형식으로 Response

수정
- 백엔드 : API 엔드포인트 명명 변경 (/api/tide-cycles) (Rest API 규칙 적용)
- 백엔드 : Get Method 형식에 따라 request 코드 변경
- 프론트엔드 : API 엔드포인트 변경점 적용
- 프론트엔드 : Vuex 내 함수명 중복으로 인해 발생하는 함수 중복 호출 개선
- 프론트엔드 : API Error로 인해 localstorage에 Error값이 반영된 상태에서, 사이트 재접속 시 fetch 진행할 수 있도록 조건 개선