### PR TITLE
Refactor (4) - 2 : 기능 수정 (낚시터 리스트 내 날씨 정보 Fetch / 외부 API 호출)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 > 메인 이미지 클릭 시, 프로젝트 발표 자료로 이동됩니다!
 
 ## 🔍 프로젝트 개요
-Snapish는 대한민국 1,000만 낚시인들을 위한 딥러닝 기반 금어종 판별 시스템입니다. 국립수산과학원의 [금어기·금지체장 정보](https://www.nifs.go.kr/contents/actionContentsCons0148.do)를 기반으로 개발되었으며, 낚시 종사자들의 법규 준수와 해양 생태계 보호를 지원합니다. 현재 17개 어종에 대해 88%의 탐지 정확도를 달성했으며, 사용자 참여형 데이터 수집을 통해 95% 이상의 정확도 달성을 목표로 하고 있습니다.
+Snapish는 대한민국 1,000만 낚시인들을 위한 딥러닝 기반 금어종 판별 시스템입니다. 국립수산과학원의 [금어기·금지체장 정보](https://www.nifs.go.kr/contents/actionContentsCons0148.do)를 기반으로 개발되었으며, 낚시 종사자들의 법규 준수와 해양 생태계 보호를 지원합니다. 현재 17개 어종에 대해 88%(mAP50)의 탐지 정확도를 달성했으며, 인공지능 모델 레이어 개선과 사용자 참여형 데이터 수집을 통해 95% 이상의 정확도 달성을 목표로 하고 있습니다.
 
 ## 📌 프로젝트 정보
 - **기간**: 2024.12.03 ~ 2025.01.02 (평일 26일)
 - **인원**: 4인
 - **역할**
-  - 👑 팀 리더 / AI 모델 개발
+  - 👑 AI 모델 개발
   - 💻 백엔드 개발
   - 🎨 프론트엔드 개발
   - 📊 DB 설계 및 데이터 수집
  
 ## ✨ 주요 기능
-- 🔍 17개 주요 어종/금어종 판별 기능 제공
+- 🔍 17개 주요 금어기 판별 기능 제공
 - 📖 어종별 특징 및 금지체장 가이드라인 제공
 - 📝 내가 잡은 물고기 리스팅 기록 시스템 제공
 - 🌊 오늘의 낚시 스팟 및 물떼/날씨 정보 제공
@@ -76,32 +76,60 @@ conda activate snapish
 - 🔬 [모델 학습 프로세스](https://www.kaggle.com/code/twoimo/yolo11-fish-transfer-learning) → `/backend/`
 
 ### 3️⃣ 서비스 실행
-백엔드 서버:
-```bash
-# Windows
-$env:FLASK_APP="main.py"
-flask run --host=0.0.0.0
 
-# Mac/Linux
-export FLASK_APP="main.py"
-flask run --host=0.0.0.0
+#### 데이터베이스 설정
+```bash
+# MySQL 서버 실행 확인
+mysql -u root -p
+# 데이터베이스 생성
+CREATE DATABASE snapish;
+# 데이터베이스 사용자 설정
+GRANT ALL PRIVILEGES ON snapish.* TO 'snapish_user'@'localhost' IDENTIFIED BY 'your_password';
+FLUSH PRIVILEGES;
 ```
 
-프론트엔드 개발 서버:
+#### 포트 설정
+```bash
+# 백엔드 포트 설정 (.env 파일)
+# 프론트엔드 포트 설정 (vue.config.js, .env)
+```
+
+#### 백엔드 서버 실행:
+```bash
+# Windows
+cd backend
+$env:FLASK_APP="main.py"
+flask run --host=0.0.0.0 --port=5000
+
+# Mac/Linux
+cd backend
+export FLASK_APP="main.py"
+flask run --host=0.0.0.0 --port=5000
+```
+
+#### 프론트엔드 개발 서버 실행:
 ```bash
 cd frontend
 npm install
 npm run serve
 ```
 
+#### 서비스 접속
+서비스 실행 후, Google Chrome 브라우저를 열고 다음 URL로 접속하세요:
+```
+http://localhost:80/
+```
+> 💡 백엔드 서버(5000번 포트)와 프론트엔드 서버(80번 포트)가 모두 정상 작동해야 서비스가 정상적으로 동작합니다.
+
 ## 📈 성과 및 향후 계획
 
 ### 🏆 현재 성과
-- 17개 어종 대상 식별 정확도 88% 달성
+- 17개 어종 대상 식별 정확도 88% 달성 (mAP50)
 - 전국 낚시터 약 2,000개 이상의 데이터베이스 구축
 
 ### 🎯 개선 계획
-- 크라우드소싱 기반 데이터 수집으로 정확도 95% 이상 달성
+- 인공지능 모델 성능 개선 (Self-supervised learning, Vision transformer)
+- 사용자 참여형 데이터 수집으로 정확도 95% 이상 달성
 - 탐지 가능한 물고기 어종 확대 (30종 이상, 바다 고기, 민물 고기 등)
 - 실시간 낚시터 정보 공유 커뮤니티 기능 구현
 - 낚시터 스토어 및 선박 사전 예약 기능 구현

--- a/backend/routes/route.py
+++ b/backend/routes/route.py
@@ -15,7 +15,7 @@ import requests
 from config import BaseConfig
 from decorator import token_required
 from services.weather_service import get_sea_weather_by_seapostid, get_weather_by_coordinates
-from services.lunar_mulddae import get_mulddae_cycle, calculate_moon_phase
+from services.lunar_tide_cycle_info import get_tide_cycle, calculate_moon_phase
 from services.openai_assistant import assistant_talk_request, assistant_talk_get
 from utils import allowed_file, optimize_image, get_full_url, success_response, error_response
 
@@ -33,7 +33,7 @@ def set_route(app: Flask, model, device):
 
     # 물떼 정보 받아오기
     @app.route('/api/tide-cycles', methods=['GET'])
-    def get_mulddae():
+    def get_tide_cycles_info():
         now_date = request.args.get('nowdate')
         if not now_date:
             return error_response("'nowdate' 파라미터가 필요합니다.",
@@ -47,7 +47,7 @@ def set_route(app: Flask, model, device):
                                 400)
 
         try:
-            lunar_date, seohae, other = get_mulddae_cycle(parsed_date)
+            lunar_date, seohae, other = get_tide_cycle(parsed_date)
             moon_phase = calculate_moon_phase(parsed_date)
             
             json_result = {

--- a/backend/routes/route.py
+++ b/backend/routes/route.py
@@ -596,7 +596,7 @@ def set_route(app: Flask, model, device):
         
 
     # Endpoint to handle avatar upload
-    @app.route('/profile/avatar', methods=['POST', 'GET'])
+    @app.route('/profile/avatar', methods=['POST'])
     @token_required
     def upload_avatar(user_id):
         if 'avatar' not in request.files:

--- a/backend/routes/route.py
+++ b/backend/routes/route.py
@@ -563,7 +563,7 @@ def set_route(app: Flask, model, device):
             logging.error(f"Error in get_detections: {e}")
             return jsonify({'error': 'Internal server error'}), 500
 
-    @app.route('/api/map_fishing_spot', methods=['POST', 'GET'])
+    @app.route('/api/map_fishing_spot', methods=['GET', 'POST'])
     # 추후 Token 관련 데코레이터 ��가할 것
     def map_fishing_spot():
         session = Session()
@@ -632,7 +632,7 @@ def set_route(app: Flask, model, device):
             return jsonify({'error': 'Invalid file type'}), 400
         
     # 요청 지점 위치와 가장 가까운 관측소의 해양 날씨 API 호출
-    @app.route('/api/get-seaweather', methods=['POST'])
+    @app.route('/api/weather/sea', methods=['POST'])
     def get_sea_weather_api():
         lat = request.form.get('lat')
         lon = request.form.get('lon')
@@ -733,7 +733,7 @@ def set_route(app: Flask, model, device):
                                 'Internal Server Error', 
                                 500)
             
-    @app.route('/api/get-weather', methods=['POST'])
+    @app.route('/api/weather/land', methods=['POST'])
     def get_weather_api():
         try:
             lat = request.form.get('lat')

--- a/backend/routes/route.py
+++ b/backend/routes/route.py
@@ -32,7 +32,7 @@ def set_route(app: Flask, model, device):
         return 'Welcome to SNAPISH'
 
     # 물떼 정보 받아오기
-    @app.route('/api/tidecycle', methods=['GET'])
+    @app.route('/api/tide-cycles', methods=['GET'])
     def get_mulddae():
         now_date = request.args.get('nowdate')
         if not now_date:

--- a/backend/services/lunar_tide_cycle_info.py
+++ b/backend/services/lunar_tide_cycle_info.py
@@ -2,14 +2,14 @@ from korean_lunar_calendar import KoreanLunarCalendar
 from datetime import datetime
 
  ## Initial 
-eight_mulddae_cycle = {
+eight_tide_cycle = {
     1: '8물', 2: '9물', 3: '10물', 4: '11물', 5: '12물', 6: '13물', 7: '14물',
     8: '조금', 9: '1물', 10: '2물', 11: '3물', 12: '4물', 13: '5물', 14: '6물', 15: '7물',
     16: '8물', 17: '9물', 18: '10물', 19: '11물', 20: '12물', 21: '13물', 22: '14물',
     23: '조금', 24: '1물', 25: '2물', 26: '3물', 27: '4물', 28: '5물', 29: '6물', 30: '7물'
 }
 
-seven_mulddae_cycle = {
+seven_tide_cycle = {
     1: '7물', 2: '8물', 3: '9물', 4: '10물', 5: '11물', 6: '12물', 7: '13물',
     8: '조금', 9: '무시', 10: '1물', 11: '2물', 12: '3물', 13: '4물', 14: '5물', 15: '6물',
     16: '7물', 17: '8물', 18: '9물', 19: '10물', 20: '11물', 21: '12물',
@@ -17,7 +17,7 @@ seven_mulddae_cycle = {
 }
 
 # 음력 기반 물때 호출
-def get_mulddae_cycle(nowdate):
+def get_tide_cycle(nowdate):
     try:
         # Calendar 불러오기
         calendar = KoreanLunarCalendar()
@@ -30,13 +30,13 @@ def get_mulddae_cycle(nowdate):
         lunar_nowdate = calendar.LunarIsoFormat()
         lunar_nowdate_day = int(lunar_nowdate.split("-")[-1])
         
-        seohae_mulddae = seven_mulddae_cycle[lunar_nowdate_day]
-        other_mulddae = eight_mulddae_cycle[lunar_nowdate_day]
+        seohae_tide_cycle = seven_tide_cycle[lunar_nowdate_day]
+        other_tide_cycle = eight_tide_cycle[lunar_nowdate_day]
         
-        return lunar_nowdate, seohae_mulddae, other_mulddae
+        return lunar_nowdate, seohae_tide_cycle, other_tide_cycle
     
     except Exception as e:
-        print(f"get_mulddae_cycle : Error Occured on {e}")
+        print(f"get_tide_cycle : Error Occured on {e}")
         return None, None, None
 
 

--- a/frontend/src/components/MapLocationWeatherSea.vue
+++ b/frontend/src/components/MapLocationWeatherSea.vue
@@ -73,7 +73,7 @@
 </template>
 
 <script>
-import { fetchSeaPostidByCoordinates } from '../services/locationService';
+import { fetchSeaPostidByCoordinates } from '../services/weatherService.js';
 
 export default {
   props: {

--- a/frontend/src/services/locationService.js
+++ b/frontend/src/services/locationService.js
@@ -7,8 +7,8 @@ export async function fetchSeaPostidByCoordinates(lat, lon) {
   try {
     const response = await axios.post(
       apisealocBaseUrl,
-      new URLSearchParams({ lat: lat, lon: lon }).toString()
-      , {
+      new URLSearchParams({ lat: lat, lon: lon }).toString(), 
+      {
         headers: {
         "Content-Type": "application/x-www-form-urlencoded",
         }

--- a/frontend/src/services/locationService.js
+++ b/frontend/src/services/locationService.js
@@ -1,34 +1,3 @@
-import axios from "@/axios";
-
-const baseUrl = process.env.VUE_APP_BASE_URL;
-const apisealocBaseUrl = `${baseUrl}/api/get-seaweather`;
-
-export async function fetchSeaPostidByCoordinates(lat, lon) {
-  try {
-    const response = await axios.post(
-      apisealocBaseUrl,
-      new URLSearchParams({ lat: lat, lon: lon }).toString(), 
-      {
-        headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        }
-      }
-    );
-
-    if (response.status === 200) {
-      return response.data.data;
-
-    } else {
-      return null
-    }
-    
-      
-  } catch (error) {
-      console.error("Error fetching sea weather data:", error);
-    return { error: error.message };
-  }
-}
-
 export function getCurrentLocation() {
     return new Promise((resolve, reject) => {
       if (!navigator.geolocation) {

--- a/frontend/src/services/locationService.js
+++ b/frontend/src/services/locationService.js
@@ -1,7 +1,7 @@
 import axios from "@/axios";
 
 const baseUrl = process.env.VUE_APP_BASE_URL;
-const apisealocBaseUrl = `${baseUrl}/backend/closest-sealoc`;
+const apisealocBaseUrl = `${baseUrl}/api/get-seaweather`;
 
 export async function fetchSeaPostidByCoordinates(lat, lon) {
   try {
@@ -14,9 +14,17 @@ export async function fetchSeaPostidByCoordinates(lat, lon) {
         }
       }
     );
-    return response.data;
+
+    if (response.status === 200) {
+      return response.data.data;
+
+    } else {
+      return null
+    }
+    
+      
   } catch (error) {
-      console.error("Error fetching weather data:", error);
+      console.error("Error fetching sea weather data:", error);
     return { error: error.message };
   }
 }

--- a/frontend/src/services/mulddaeService.js
+++ b/frontend/src/services/mulddaeService.js
@@ -12,7 +12,13 @@ export async function fetchMulddae(date) {
         },
       }
     );
-    return response.data.data;
+
+    if (response.status === 200) {
+      return response.data.data;
+
+    } else {
+      return null;
+    }
   } catch (error) {
     console.error("Error fetching mulddae data:", error);
     return null;

--- a/frontend/src/services/mulddaeService.js
+++ b/frontend/src/services/mulddaeService.js
@@ -6,7 +6,8 @@ const apimulddaeBaseUrl = `${baseUrl}/api/tide-cycles`;
 export async function fetchMulddae(date) {
   console.log(`Call_fetchMulddae : ${date}`);
   try {
-    const response = await axios.get(apimulddaeBaseUrl,{
+    const response = await axios.get(
+      apimulddaeBaseUrl,{
         params: {
           nowdate: date,
         },

--- a/frontend/src/services/mulddaeService.js
+++ b/frontend/src/services/mulddaeService.js
@@ -1,7 +1,7 @@
 import axios from "@/axios"; // Axios 인스턴스 임포트
 
 const baseUrl = process.env.VUE_APP_BASE_URL;
-const apimulddaeBaseUrl = `${baseUrl}/api/tidecycle`;
+const apimulddaeBaseUrl = `${baseUrl}/api/tide-cycles`;
 
 export async function fetchMulddae(date) {
   console.log(`Call_fetchMulddae : ${date}`);

--- a/frontend/src/services/weatherService.js
+++ b/frontend/src/services/weatherService.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
 const baseUrl = process.env.VUE_APP_BASE_URL;
-const apiWeatherBaseUrl = `${baseUrl}/api/get-weather`;
-const apisealocBaseUrl = `${baseUrl}/api/get-seaweather`;
+const apiWeatherBaseUrl = `${baseUrl}/api/weather/land`;
+const apiSeaWeatherBaseUrl = `${baseUrl}/api/weather/sea`;
 
 // Land Weather
 export async function fetchWeatherByCoordinates(lat, lon) {
@@ -32,7 +32,7 @@ export async function fetchWeatherByCoordinates(lat, lon) {
 export async function fetchSeaPostidByCoordinates(lat, lon) {
   try {
     const response = await axios.post(
-      apisealocBaseUrl,
+      apiSeaWeatherBaseUrl,
       new URLSearchParams({ lat: lat, lon: lon }).toString(), 
       {
         headers: {

--- a/frontend/src/services/weatherService.js
+++ b/frontend/src/services/weatherService.js
@@ -1,9 +1,10 @@
 import axios from 'axios';
 
 const baseUrl = process.env.VUE_APP_BASE_URL;
-const apiWeatherBaseUrl = `${baseUrl}/backend/get-weather`;
+const apiWeatherBaseUrl = `${baseUrl}/api/get-weather`;
+const apisealocBaseUrl = `${baseUrl}/api/get-seaweather`;
 
-
+// Land Weather
 export async function fetchWeatherByCoordinates(lat, lon) {
   try {
     const response = await axios.post(
@@ -15,9 +16,40 @@ export async function fetchWeatherByCoordinates(lat, lon) {
         }
       }
     );
-    return response.data;
+    if (response.status === 200) {
+      return response.data.data;
+
+    } else {
+      return null
+    }
   } catch (error) {
     console.error("Error fetching weather data:", error);
+    return { error: error.message };
+  }
+}
+
+// Sea Weather
+export async function fetchSeaPostidByCoordinates(lat, lon) {
+  try {
+    const response = await axios.post(
+      apisealocBaseUrl,
+      new URLSearchParams({ lat: lat, lon: lon }).toString(), 
+      {
+        headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        }
+      }
+    );
+
+    if (response.status === 200) {
+      return response.data.data;
+
+    } else {
+      return null
+    }
+    
+  } catch (error) {
+      console.error("Error fetching sea weather data:", error);
     return { error: error.message };
   }
 }


### PR DESCRIPTION
기존
- 낚시터 정보 리스트 페이지 렌더링
- 렌더링된 페이지의 낚시터 정보 리스트에서 특정 지점 클릭 시 Sliding Panel 나타남
- Sliding Panel 내 3개의 토글, 그 중 날씨 Toggle 클릭시 날씨 API 호출 함수 실행
- 지점 Type이 바다인 경우, 지상 날씨 API -> 해양 날씨 API 순으로 호출
- 지점 Type이 바다가 아닌 경우, 지상 날씨 API만 호출

수정
- 백엔드 : 
   - API 엔드포인트 명명 변경 
       - 지상 : `/api/weather/land`
       - 해양 : `/api/weather/sea`
   - HTTP Method POST 요청으로 고정
   - Response 공용 포맷 적용
   - 해양 날씨 호출 시, 요청 지점 기준 가장 가까운 위치의 관측소를 검출하는 방식을 SQL 쿼리 방식에서  ORM 방식으로 수정
   - API의 각 과정마다 적절하게 try-except 적용을 통해 Error 발생 최소화
 
- 프론트엔드 :
   - 백엔드 API 엔드포인트 변경에 따라 각 Fetch 함수별로 요청 API 주소 수정
   - `fetchSeaPostidByCoordinates` 함수 위치를 weatherService.js 파일로 조정 : 목적에 맞는 함수 위치로 조정
   - Response 공용 포맷에 맞춰 fetch 함수 return 형식 수정


기타
- Fork된 메인 Branch에서 수정 내역 Merge